### PR TITLE
Use <silent> mappings for floaterm_repl buffer

### DIFF
--- a/autoload/floaterm_repl.vim
+++ b/autoload/floaterm_repl.vim
@@ -47,8 +47,8 @@ endfunction
 
 
 function! s:setupfloaterm_popup() abort
-    nmap<buffer> q :q<CR>
-    nmap<buffer> <ESC> :q<CR>
+    nmap <silent><buffer> q :q<CR>
+    nmap <silent><buffer> <ESC> :q<CR>
 endfunction
 
 augroup floatermrepl


### PR DESCRIPTION
Hi, Could we use silent mappings while closing the repl buffer.